### PR TITLE
LASSO-like penalty term to the PI model.

### DIFF
--- a/R/2c.iph_inhomogenity_regression.R
+++ b/R/2c.iph_inhomogenity_regression.R
@@ -4,6 +4,7 @@
 #' @param y Vector or data.
 #' @param X Model matrix (no intercept needed).
 #' @param B0 Initial regression coefficients (optional).
+#' @param lasso Lasso penalty smoothness parameter (optional).
 #' @param X2 Model matrix for the inhomogeneity parameter (no intercept needed).
 #' @param prop_f Regression function for the intensity function.
 #' @param inhom_f Regression function for the intensity function.
@@ -45,6 +46,7 @@ setMethod(
            prop_f = NULL,
            inhom_f = NULL,
            B0 = numeric(0),
+           lasso = 0,
            stepsEM = 1000,
            methods = c("RK", "UNI"),
            rkstep = NA,
@@ -153,7 +155,7 @@ setMethod(
         beta1 <- head(beta,length(obs)) 
         beta2 <- if(rightCensored){tail(beta, length(rcens))}else{tail(beta, nrow(rcens))}
         
-        return(LL_base(h, alpha, S, beta1, beta2, obs, weight, rcens, rcweight, scale1, scale2, gfun_name))
+        return(LL_base(h, alpha, S, beta1, beta2, obs, weight, rcens, rcweight, scale1, scale2, gfun_name)-lasso*sum(abs(theta)))
       }
     }
     

--- a/src/EM_LL_UNI_PI.cpp
+++ b/src/EM_LL_UNI_PI.cpp
@@ -23,7 +23,8 @@ using namespace Rcpp;
  //' @param gfun_name Name of the transformation function to be applied to observations (e.g., "scale", "log", "sqrt").
  //' 
  // [[Rcpp::export]]
- double logLikelihood_UNIs_PI(double h, arma::vec & alpha,
+ double logLikelihood_UNIs_PI(double h,
+                              arma::vec & alpha,
                               arma::mat & S,
                               SEXP beta1,
                               SEXP beta2,


### PR DESCRIPTION
A LASSO-like penalty term is added to the estimation procedure of the PI  model. The user can decide how much importance the LASSO has in the inhomogeneous likelihood maximisation of the EM algorithm. Defaults to zero (no penalty).